### PR TITLE
New calibrate module and woa_calibration.py script

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,3 +18,7 @@ exclude_lines =
     except ConnectionError
     self.logger.error
     self.logger.exception
+    except NameError
+
+    # Hard to test delayed mode file update
+    if 'D' in code.upper

--- a/biofloat/calibrate.py
+++ b/biofloat/calibrate.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import xray
+
+from biofloat.utils import o2sat, convert_to_mll
+
+'''Collection of functions derived from biofloat Notebook 
+explore_surface_oxygen_and_WOA.ipynb. 
+'''
+
+# Global woa dictionary of urls to the World Ocean Atlas monthly climatology
+woa_tmpl = 'http://data.nodc.noaa.gov/thredds/dodsC/woa/WOA13/DATA/o2sat/netcdf/all/1.00/woa13_all_O{:02d}_01.nc'
+woa = {}
+for m in range(1,13):
+    woa[m] = woa_tmpl.format(m)
+
+
+def round_to(n, increment, mark):
+    '''Round n to nearest increment at mark, e.g.:
+        In [10]: round_to(36.1, 1, 0.5)
+        Out[10]: 36.5
+    '''
+    correction = mark if n >= 0 else -mark
+    return int( n / increment) + correction
+
+def woa_o2sat(month, depth, lon, lat):
+    '''Perform the WOA climatology database lookup for the temporal
+    spatial corrdinates passed in.
+    '''
+    ds = xray.open_dataset(woa[month], decode_times=False)
+
+    return ds.loc[dict(lon=lon, lat=lat, depth=depth)]['O_an'].values[0]
+
+def surface_mean(df, max_pressure=10):
+    '''Return DataFrame of surface mean values for data with pressure 
+    less than max_pressure.
+    '''
+    return df.query(('pressure < {:d}').format(max_pressure)).groupby(
+            level=['wmo', 'time', 'lon', 'lat', 'profile']).mean()
+
+def add_columns_for_groupby(df):
+    '''Add columns derived from the index to make groupbys easier.
+    '''
+    df['lon'] = df.index.get_level_values('lon')
+    df['lat'] = df.index.get_level_values('lat')
+    df['month'] = df.index.get_level_values('time').month
+    df['year'] = df.index.get_level_values('time').year
+    df['wmo'] = df.index.get_level_values('wmo')
+
+    return df
+
+def monthly_mean(df):
+    '''Return DataFrame of monthly mean of the float data. These columns need
+    to be in df: ['wmo', 'year', 'month']
+    '''
+    mdf = df.groupby(['wmo', 'year', 'month']).mean()
+    mdf['o2sat'] = 100 * (mdf.DOXY_ADJUSTED / o2sat(mdf.PSAL_ADJUSTED, mdf.TEMP_ADJUSTED))
+
+    return mdf
+
+def add_columns_for_woa_lookup(df):
+    '''Add rounded ilat and ilon columns to facilitate WOA lookup
+    '''
+    df['ilon'] = df.apply(lambda x: round_to(x.lon, 1, 0.5), axis=1)
+    df['ilat'] = df.apply(lambda x: round_to(x.lat, 1, 0.5), axis=1)
+
+    return df
+
+def add_column_from_woa(df, pressure=5.0):
+    '''Adds 'woa_o2sat' column to df at provided pressure.
+    '''
+    df['month'] = df.index.get_level_values('month')
+    df['woa_o2sat'] = df.apply(lambda x: woa_o2sat(x.month, pressure, x.ilon, x.ilat), axis=1)
+
+    return df
+
+
+def calculate_gain(df):
+    '''Calculate gain. Add 'wmo' column back and make a Python datetime index as column 'date'. 
+    Return a simplified DataFrame with just O2 and gain columns.
+    '''
+    gdf = df[['o2sat', 'woa_o2sat']].copy()
+    gdf['wmo'] = gdf.index.get_level_values('wmo')
+    years = gdf.index.get_level_values('year')
+    months = gdf.index.get_level_values('month')
+    gdf['date'] = pd.to_datetime(years * 100 + months, format='%Y%m')
+    gdf['gain'] = gdf.woa_o2sat / gdf.o2sat
+
+    return gdf
+

--- a/scripts/woa_calibration.py
+++ b/scripts/woa_calibration.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+import sys
+from os.path import join, dirname, abspath, expanduser
+parent_dir = join(dirname(__file__), "../")
+sys.path.insert(0, parent_dir)
+
+import logging
+import matplotlib as plt
+import xray
+
+from biofloat import ArgoData
+from biofloat.utils import o2sat, convert_to_mll
+from biofloat.calibrate import (woa_o2sat, surface_mean, monthly_mean, 
+                                add_columns_for_groupby, add_columns_for_woa_lookup,
+                                add_column_from_woa, calculate_gain
+                               )
+
+class WOA_Calibrator(object):
+
+    logger = logging.getLogger(__name__)
+    _handler = logging.StreamHandler()
+    _formatter = logging.Formatter('%(levelname)s %(asctime)s %(filename)s '
+                                  '%(funcName)s():%(lineno)d %(message)s')
+    _handler.setFormatter(_formatter)
+    logger.addHandler(_handler)
+
+    _log_levels = (logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG)
+
+    def make_plot(self):
+        plt.style.use('ggplot')
+        plt.rcParams['figure.figsize'] = (18.0, 4.0)
+        gdf[['o2sat', 'woa_o2sat']].unstack(level=0).plot()
+        gdf[['gain']].unstack(level=0).plot()
+
+
+
+    def process(self):
+        self.logger.setLevel(self._log_levels[self.args.verbose])
+        ad = ArgoData(verbosity=self.args.verbose, 
+                      cache_file=self.args.cache_file)
+
+        if self.args.wmo:
+            wmo_list = self.args.wmo
+        else:
+            wmo_list = ad.get_cache_file_oxy_count_df()['wmo'].tolist()
+
+        for wmo in wmo_list:
+            self.logger.info('Reading float %s from %s', wmo, self.args.cache_file)
+            df = ad.get_float_dataframe([wmo],
+                                        max_profiles=self.args.profiles, 
+                                        max_pressure=self.args.pressure)
+
+            sdf = surface_mean(df)
+            sdf = add_columns_for_groupby(sdf)
+            msdf = monthly_mean(sdf)
+            msdf = add_columns_for_woa_lookup(msdf)
+            self.logger.info('Doing WOA lookup')
+            woadf = add_column_from_woa(msdf)
+            gdf = calculate_gain(woadf)
+
+            print(gdf.groupby('wmo').gain.mean())
+
+    def process_command_line(self):
+        import argparse
+        from argparse import RawTextHelpFormatter
+
+        examples = 'Examples:' + '\n' 
+        examples += '---------' + '\n' 
+        examples += sys.argv[0] + " --cache_file /data/biofloat/biofloat_fixed_cache_age365.hdf\n"
+        examples += "\n\n"
+    
+        parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter,
+                    description='Script to compare surface oxygen saturation values\n'
+                                'with data from the World Ocean Atlas and calculate\n'
+                                'a gain factor that can be used to calibrate Bio-Argo\n'
+                                'float measurements.',
+                    epilog=examples)
+                                             
+        parser.add_argument('--cache_file', action='store', help='full path to cache file',
+                                            required=True)
+        parser.add_argument('--wmo', action='store', nargs='*', default=[],
+                                     help='One or more WMO numbers to read from cache file')
+        parser.add_argument('--profiles', action='store', 
+                                     help='Maximum number of profiles to read in')
+        parser.add_argument('--pressure', action='store', 
+                                     help='Maximum pressure to read in')
+        parser.add_argument('-v', '--verbose', nargs='?', choices=[0,1,2,3], type=int,
+                            help='0: ERROR, 1: WARN, 2: INFO, 3:DEBUG', default=0, const=2)
+
+        self.args = parser.parse_args()
+
+
+if __name__ == '__main__':
+
+    woac = WOA_Calibrator()
+    woac.process_command_line()
+    woac.process()
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "biofloat",
-    version = "0.2.0",
+    version = "0.3.0",
     packages = find_packages(),
     requires = ['Python (>=2.7)'],
     install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
         'simpletable>=0.2',
         'xray>=0.6'
     ],
-    scripts = ['scripts/load_biofloat_cache.py'],
+    scripts = ['scripts/load_biofloat_cache.py',
+               'scripts/woa_calibration.py'],
 
     # metadata for upload to PyPI
     author = "Mike McCann",

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 coverage run --source=biofloat scripts/load_biofloat_cache.py --age 3000 --profiles 1
 coverage run -a --source=biofloat tests/unit_tests.py
+coverage run -a --source=biofloat scripts/woa_calibration.py --cache_file ~/biofloat_fixed_cache_age3000_profiles1.hdf
 coverage report -m
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -105,6 +105,12 @@ class DataTest(unittest.TestCase):
         df = self.ad.get_cache_file_oxy_count_df(max_profiles=2)
         self.assertNotEqual(len(df), 0)
 
+    def test_get_update_datetime(self):
+        # Any random delayed mode file will do...
+        dt = self.ad._get_update_datetime(
+                'http://tds0.ifremer.fr/thredds/dodsC/CORIOLIS-ARGO-GDAC-OBS/aoml/5901336/profiles/D5901336_082.nc')
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
After creating a cache file the woa_calibration.py script can be run to compute the gain, e.g.:

```bash
$ scripts/load_biofloat_cache.py --wmo 5903612
$ scripts/woa_calibration.py --cache_file /home/mccann/biofloat_fixed_cache_wmo5903612.hdf -v
INFO 2015-11-20 14:31:48,009 ArgoData.py get_cache_file_oxy_count_df():613 Read oxy_count_df from cache
INFO 2015-11-20 14:31:48,010 woa_calibration.py process():49 Reading float 5903612 from /home/mccann/biofloat_fixed_cache_wmo5903612.hdf
INFO 2015-11-20 14:31:54,535 woa_calibration.py process():58 Doing WOA lookup
wmo
5903612    1.07087
```